### PR TITLE
fix b_med color in pale theme

### DIFF
--- a/desktop/sources/scripts/lib/theme.js
+++ b/desktop/sources/scripts/lib/theme.js
@@ -12,7 +12,7 @@ function Theme (default_theme = { background: '#222', f_high: '#fff', f_med: '#7
   this.collection = {
     default: default_theme,
     noir: { background: '#222', f_high: '#fff', f_med: '#777', f_low: '#444', f_inv: '#fff', b_high: '#000', b_med: '#aaa', b_low: '#000', b_inv: '#000' },
-    pale: { background: '#e1e1e1', f_high: '#000', f_med: '#777', f_low: '#aaa', f_inv: '#000', b_high: '#000', b_med: '#aaa', b_low: '#ccc', b_inv: '#fff' }
+    pale: { background: '#e1e1e1', f_high: '#000', f_med: '#777', f_low: '#aaa', f_inv: '#000', b_high: '#000', b_med: '#444', b_low: '#ccc', b_inv: '#fff' }
   }
 
   this.install = function (host = document.body, callback) {


### PR DESCRIPTION
`b_med` had the same value as `f_low`, function letters had the same color as their background rects
<img width="147" alt="capture" src="https://user-images.githubusercontent.com/1162231/48848630-b3194f80-eda4-11e8-9dd0-b2cfde9e7e8b.png">