### PR TITLE
Updated input list for MIDI and F operators in README to match actual inputs and outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ You can follow the [guide](GUIDE.md) to get started and play your first sounds. 
 - `C` **clock**('rate, mod): Outputs a constant value based on the runtime frame.
 - `D` **delay**('rate, offset): Bangs on a fraction of the runtime frame.
 - `E` **east**: Moves eastward, or bangs.
-- `F` **if**(a, b): Outputs `1` if inputs are equal, otherwise `0`.
+- `F` **if**(a, b): Outputs `*` if inputs are equal, otherwise `.`.
 - `G` **generator**('x, 'y, 'len): Writes distant operators with offset.
 - `H` **halt**('len): Stops southward operators from operating.
 - `I` **increment**(min, max): Increments southward operator.
@@ -53,6 +53,7 @@ You can follow the [guide](GUIDE.md) to get started and play your first sounds. 
 - `#` **comment**: Comments a line, or characters until the next hash.
 - `;` **udp**('len): Sends a string via UDP to localhost.
 - `:` **midi**('velocity, 'length, channel, octave, note): Sends Midi a midi note.
+- `:` **midi**('channel, 'octave, 'note, velocity, length): Sends Midi a midi note.
 - `/` **door**('id, val): Hosts a nested Orca grid.
 
 ## Controls


### PR DESCRIPTION
The ```:``` operator's inputs were in a different order in README.MD and the code itself

The ```F``` operator's ouputs were listed as ```1``` and ```0``` instead of ```*``` and ```.```