### PR TITLE
Added MIDI clock syncing

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,14 @@ In console, type `terminal.io.midi.list()` to see the list of available midi dev
 
 In console, type `terminal.io.midi.select(1)` to select the second midi device.
 
+#### Using MIDI beat clock instead of the built in clock
+
+Orca comes with its own internal clock but you can configure it to receive its clock signal from a MIDI input.
+Press `Ctrl+Space` to cycle through available clocks (built in or MIDI inputs).
+The MIDI clock listens for the START and STOP signals from the midi device to run.
+
+*Warning*: Note length when using the MIDI clock is currently based on note length at 120 BPM.
+
 ## UDP
 
 The [UDP](https://nodejs.org/api/dgram.html#dgram_socket_send_msg_offset_length_port_address_callback) operator `;` locks each consecutive eastwardly ports. For example, `;hello`, will send the string "hello", on bang, to the port `49160` on `localhost`

--- a/desktop/sources/index.html
+++ b/desktop/sources/index.html
@@ -18,7 +18,7 @@
       const { app } = require('electron').remote
 
       terminal.install(document.body)
-      
+
       terminal.controller.add("default","*","About",() => { require('electron').shell.openExternal('https://github.com/hundredrabbits/Orca'); },"CmdOrCtrl+,")
       terminal.controller.add("default","*","Fullscreen",() => { app.toggleFullscreen(); },"CmdOrCtrl+Enter")
       terminal.controller.add("default","*","Hide",() => { app.toggleVisible(); },"CmdOrCtrl+H")
@@ -48,7 +48,7 @@
       terminal.controller.add("default","Program","Decr. Col",() => { terminal.modGrid(-1,0); },"[")
       terminal.controller.add("default","Program","Incr. Row",() => { terminal.modGrid(0,1); },"}")
       terminal.controller.add("default","Program","Decr. Row",() => { terminal.modGrid(0,-1); },"{")
-      terminal.controller.add("default", "Program", "Next clock", () => {terminal.nextClock()}, "CmdOrCtrl+Space")
+      terminal.controller.add("default", "Program", "Next clock", () => {terminal.nextClock()}, "Ctrl+Space")
 
 
       terminal.controller.add("default","View","Zoom In",() => { terminal.modZoom(0.25); },"CmdOrCtrl+=")

--- a/desktop/sources/index.html
+++ b/desktop/sources/index.html
@@ -8,17 +8,17 @@
     <link rel="stylesheet" type="text/css" href="links/fonts.css"/>
     <link rel="stylesheet" type="text/css" href="links/main.css"/>
     <link rel="stylesheet" type="text/css" href="links/theme.css"/>
-    
+
     <title>Orca</title>
   </head>
   <body>
-    <script>     
+    <script>
       const Terminal = require('./scripts/terminal')
       const terminal = new Terminal()
       const { app } = require('electron').remote
 
       terminal.install(document.body)
-
+      
       terminal.controller.add("default","*","About",() => { require('electron').shell.openExternal('https://github.com/hundredrabbits/Orca'); },"CmdOrCtrl+,")
       terminal.controller.add("default","*","Fullscreen",() => { app.toggleFullscreen(); },"CmdOrCtrl+Enter")
       terminal.controller.add("default","*","Hide",() => { app.toggleVisible(); },"CmdOrCtrl+H")
@@ -48,6 +48,8 @@
       terminal.controller.add("default","Program","Decr. Col",() => { terminal.modGrid(-1,0); },"[")
       terminal.controller.add("default","Program","Incr. Row",() => { terminal.modGrid(0,1); },"}")
       terminal.controller.add("default","Program","Decr. Row",() => { terminal.modGrid(0,-1); },"{")
+      terminal.controller.add("default", "Program", "Next clock", () => {terminal.nextClock()}, "CmdOrCtrl+Space")
+
 
       terminal.controller.add("default","View","Zoom In",() => { terminal.modZoom(0.25); },"CmdOrCtrl+=")
       terminal.controller.add("default","View","Zoom Out",() => { terminal.modZoom(-0.25); },"CmdOrCtrl+-")

--- a/desktop/sources/scripts/clock.js
+++ b/desktop/sources/scripts/clock.js
@@ -1,0 +1,57 @@
+'use strict'
+
+class Clock {
+  constructor (bpm, callback) {
+    this.bpm = 0
+    this.callback = () => {}
+    this.timer = null
+    this.running = false
+    this.setBpm(bpm)
+  }
+
+  setCallback (callback) {
+    this.callback = callback
+  }
+
+  canSetBpm () {
+    return true
+  }
+
+  getBpm () {
+    return this.bpm
+  }
+
+  setBpm (bpm) {
+    this.bpm = bpm
+    this.reset()
+  }
+
+  reset () {
+    if (this.timer) {
+      clearInterval(this.timer)
+    }
+
+    if (this.running) {
+      this.timer = setInterval(() => { this.callback() }, (60000 / this.bpm) / 4)
+    }
+  }
+
+  setRunning (running) {
+    this.running = running
+    this.reset()
+  }
+
+  start () {
+    this.setRunning(true)
+  }
+
+  stop () {
+    this.setRunning(false)
+  }
+
+  toString () {
+    return `${this.bpm}`
+  }
+}
+
+module.exports = Clock

--- a/desktop/sources/scripts/io.js
+++ b/desktop/sources/scripts/io.js
@@ -1,16 +1,19 @@
 'use strict'
 
 const Midi = require('./io.midi')
+const MidiClock = require('./io.midi.clock')
 const Udp = require('./io.udp')
 const Osc = require('./io.osc')
 
 function IO (terminal) {
   this.midi = new Midi(terminal)
+  this.midiClock = new MidiClock(terminal)
   this.udp = new Udp(terminal)
   this.osc = new Osc(terminal)
 
   this.start = function () {
     this.midi.start()
+    this.midiClock.start()
     this.udp.start()
     this.osc.start()
     this.clear()

--- a/desktop/sources/scripts/io.js
+++ b/desktop/sources/scripts/io.js
@@ -1,19 +1,16 @@
 'use strict'
 
 const Midi = require('./io.midi')
-const MidiClock = require('./io.midi.clock')
 const Udp = require('./io.udp')
 const Osc = require('./io.osc')
 
 function IO (terminal) {
   this.midi = new Midi(terminal)
-  this.midiClock = new MidiClock(terminal)
   this.udp = new Udp(terminal)
   this.osc = new Osc(terminal)
 
   this.start = function () {
     this.midi.start()
-    this.midiClock.start()
     this.udp.start()
     this.osc.start()
     this.clear()

--- a/desktop/sources/scripts/io.midi.clock.js
+++ b/desktop/sources/scripts/io.midi.clock.js
@@ -1,0 +1,85 @@
+'use strict'
+
+class WrappedClock {
+  constructor (device) {
+    this.device = device
+    this.running = false
+    this.callback = () => {}
+    this.count = 0
+    this.started = false
+    this.signals = {
+      CLOCK: 0xF8,
+      START: 0xFA,
+      STOP: 0xFC
+    }
+  }
+
+  canSetBpm () {
+    return false
+  }
+
+  setCallback (callback) {
+    this.callback = callback
+  }
+
+  setRunning (running) {
+    this.running = running
+    this.reset()
+  }
+
+  reset () {
+    if (this.running) {
+      this.device.onmidimessage = (message) => { this.onMIDIMessage(message) }
+    } else {
+      this.device.onmidimessage = null
+    }
+  }
+
+  toString () {
+    return `${this.device.name}`
+  }
+
+  onMIDIMessage (message) {
+    switch (message.data[0]) {
+      case this.signals.CLOCK:
+        this.count = (this.count + 1) % 6
+        if (this.count == 0 && this.started) {
+          this.callback()
+        }
+        break
+      case this.signals.START:
+        this.started = true
+        break
+      case this.signals.STOP:
+        this.started = false
+        break
+    }
+  }
+}
+
+class MidiClock {
+  constructor (terminal) {
+    this.terminal = terminal
+  }
+
+  start () {
+    console.info('Starting Midi Clock...')
+    this.setup()
+  }
+
+  setup () {
+    if (!navigator.requestMIDIAccess) { return }
+    navigator.requestMIDIAccess({ sysex: false }).then((midiAccess) => { this.onMIDIAccess(midiAccess) }, (err) => {
+      console.warn('No Midi', err)
+    })
+  }
+
+  onMIDIAccess (midiAccess) {
+    const iter = midiAccess.inputs.values()
+    for (let i = iter.next(); i && !i.done; i = iter.next()) {
+      this.terminal.clocks.push(new WrappedClock(i.value))
+    }
+  }
+}
+
+module.exports = MidiClock

--- a/desktop/sources/scripts/io.midi.js
+++ b/desktop/sources/scripts/io.midi.js
@@ -1,13 +1,17 @@
 'use strict'
 
+const MidiClock = require('./io.midi.clock')
+
 function Midi (terminal) {
   this.index = 0
   this.devices = []
   this.stack = []
+  this.clock = new MidiClock(terminal)
 
   this.start = function () {
     console.info('Midi Starting..')
     this.setup()
+    this.clock.start()
   }
 
   this.clear = function () {

--- a/desktop/sources/scripts/io.midi.js
+++ b/desktop/sources/scripts/io.midi.js
@@ -95,23 +95,7 @@ function Midi (terminal) {
   }
 
   function convertChannel (id) {
-    // return [id + 144, id + 128].toString(16);
-    if (id === 0) { return [0x90, 0x80] } // ch1
-    if (id === 1) { return [0x91, 0x81] } // ch2
-    if (id === 2) { return [0x92, 0x82] } // ch3
-    if (id === 3) { return [0x93, 0x83] } // ch4
-    if (id === 4) { return [0x94, 0x84] } // ch5
-    if (id === 5) { return [0x95, 0x85] } // ch6
-    if (id === 6) { return [0x96, 0x86] } // ch7
-    if (id === 7) { return [0x97, 0x87] } // ch8
-    if (id === 8) { return [0x98, 0x88] } // ch9
-    if (id === 9) { return [0x99, 0x89] } // ch10
-    if (id === 10) { return [0x9A, 0x8A] } // ch11
-    if (id === 11) { return [0x9B, 0x8B] } // ch12
-    if (id === 12) { return [0x9C, 0x8C] } // ch13
-    if (id === 13) { return [0x9D, 0x8D] } // ch14
-    if (id === 14) { return [0x9E, 0x8E] } // ch15
-    if (id === 15) { return [0x9F, 0x8F] } // ch16
+    return [0x90 + id, 0x80 + id]
   }
 
   function convertNote (octave, note) {
@@ -119,6 +103,10 @@ function Midi (terminal) {
   }
 
   function convertLength (val, bpm) {
+    // TODO get bpm from daw midi
+    if (!bpm) {
+      bpm = 120
+    }
     return (60000 / bpm) * (val / 15)
   }
 


### PR DESCRIPTION
This allows selecting a new source for the clock from a midi device using MIDI beat clock.
Shortcut is Ctrl+Space, then start the clock in the DAW.
The orca clock can be paused without pausing the DAW with Space as before
