### PR TITLE
Fix icon path on Linux

### DIFF
--- a/desktop/main.js
+++ b/desktop/main.js
@@ -8,6 +8,12 @@ let isShown = true
 app.win = null
 
 app.on('ready', () => {
+
+  const icon = {
+    darwin: 'icon.icns',
+    linux: 'icon.png',
+    win32: 'icon.ico'
+  }[process.platform] || 'icon.ico'
   app.win = new BrowserWindow({
     width: 710,
     height: 470,
@@ -15,7 +21,7 @@ app.on('ready', () => {
     minHeight: 320,
     backgroundColor: '#000',
     resizable: true,
-    icon: __dirname + '/icon.ico',
+    icon: __dirname + '/' + icon,
     frame: process.platform !== 'darwin',
     skipTaskbar: process.platform === 'darwin',
     autoHideMenuBar: process.platform === 'darwin'


### PR DESCRIPTION
One thing I couldn't test was the icon on mac.
It was icon.ico before, but according to the electron docs it should be .icns