### PR TITLE
WIP: got midi clock sending to external midi devices.

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -24,6 +24,7 @@
     "electron-rebuild": "^1.8.4"
   },
   "dependencies": {
+    "midi-clock": "0.0.1",
     "node-osc": "^3.0.0"
   }
 }

--- a/desktop/sources/scripts/io.midi.js
+++ b/desktop/sources/scripts/io.midi.js
@@ -7,6 +7,12 @@ function Midi (terminal) {
   this.devices = []
   this.stack = []
   this.clock = new MidiClock(terminal)
+  this.signals = {
+    CLOCK: 0xF8,
+    START: 0xFA,
+    STOP: 0xFC
+  }
+
 
   this.start = function () {
     console.info('Midi Starting..')
@@ -56,6 +62,12 @@ function Midi (terminal) {
 
     device.send([channel[0], note, velocity])
     device.send([channel[1], note, velocity], length)
+  }
+
+  this.sendClock = function () {
+    let device = this.device()
+    if (!device) return
+    device.send([this.signals.CLOCK], 0)
   }
 
   this.select = function (id) {

--- a/desktop/sources/scripts/terminal.js
+++ b/desktop/sources/scripts/terminal.js
@@ -88,7 +88,7 @@ function Terminal () {
   this.reset = function () {
     this.theme.reset()
   }
-  
+
   this.prevFrame = function () {
     this.orca.f -= 2
     this.stop()
@@ -115,6 +115,7 @@ function Terminal () {
     this.selectedClock = (this.selectedClock + 1) % this.clocks.length
     this.clock().setRunning(!this.isPaused)
     this.clock().setCallback(() => this.run())
+    this.clock().setPpqmCallback(() => this.io.midi.sendClock())
 
     console.log('Select clock:', this.clock())
     this.update()


### PR DESCRIPTION
based on issue #39 , I have changed to 24 ppq using the midi-clock package which gives finer timer resolution. I have added a sendClock on the io,midi.js and added a callback in terminal to tie it all together. I have tested it with external hardware and the clock messages seem to be syncd

I think I may have slowed down the internal orca clock though. I am wondering if the microPosition should be divided by 6 instead of 24. Anyway, I will open this up to others to have a look at. 