### PR TITLE
Disable background throttling

### DIFF
--- a/desktop/main.js
+++ b/desktop/main.js
@@ -18,11 +18,11 @@ app.on('ready', () => {
     resizable: true,
     frame: process.platform !== 'darwin',
     skipTaskbar: process.platform === 'darwin',
-    autoHideMenuBar: process.platform === 'darwin'
+    autoHideMenuBar: process.platform === 'darwin',
+    webPreferences: { backgroundThrottling: false }
   })
 
   app.win.loadURL(`file://${__dirname}/sources/index.html`)
-  // app.inspect()
 
   app.win.on('closed', () => {
     win = null


### PR DESCRIPTION
This will keep running the clock consistently even when the app is in
the background