### PR TITLE
Fix midi in clock sync

### DIFF
--- a/desktop/core/io/midi.js
+++ b/desktop/core/io/midi.js
@@ -124,8 +124,6 @@ export default function Midi (terminal) {
     }
   }
 
-  this.count = 0
-
   this.receive = function (msg) {
     switch (msg.data[0]) {
       // Keys
@@ -137,10 +135,7 @@ export default function Midi (terminal) {
         break
       // Clock
       case 0xF8:
-        this.count = (this.count + 1) % 6
-        if (this.count % 4 === 0) {
-          // terminal.clock.tap()
-        }
+        terminal.clock.tap()
         break
       case 0xFA:
         console.log('Midi', 'Clock start.')


### PR DESCRIPTION
This fixes how orca works with external midi clocks. 

 - The old way tried to align the orca bpm with the pulses coming from the external midi clock, but that led to clock sku.
 - In this PR orca becomes a slave to the midi clock, advancing the orca frames on every 6th pulse, and suspending the internal orca interval. If no pulses are received from the external midi clock, orca disconnects, and resumes its previous bpm and resumes its internal interval clock.