### PR TITLE
fix for browser version

### DIFF
--- a/desktop/sources/scripts/clock.js
+++ b/desktop/sources/scripts/clock.js
@@ -108,7 +108,7 @@ export default function Clock (terminal) {
   this.setTimer = function (bpm) {
     console.log('Clock', 'New Timer ' + bpm + 'bpm')
     this.clearTimer()
-    this.timer = new Worker(path.join(__dirname, 'scripts/timer.js'))
+    this.timer = new Worker(`${__dirname}/scripts/timer.js`)
     this.timer.postMessage((60000 / bpm) / 4)
     this.timer.onmessage = (event) => { terminal.run() }
   }

--- a/index.html
+++ b/index.html
@@ -30,6 +30,7 @@
     <script type="module">
       import Terminal from "./desktop/sources/scripts/terminal.js";
       const terminal = new Terminal()
+      window.__dirname = "desktop/sources";
       window.terminal = terminal
       terminal.install(document.body)
       terminal.start()


### PR DESCRIPTION
This fixes the broken browser build caused by `__dirname` and `path.join`.

Also: I *think* that having the timer in a Worker is not going to improve anything. Do you have any measurements on this?

I understand that having a `setInterval` loop running in a Worker is going to be more precise (i.e. not desynced by other stuff happening in the main thread), **but** the timer is going to `postMessage` its tick back to the main thread anyway. So the hypothetically over-loaded main thread will cause exactly the same delay with respect to timing, as if it was running the setInterval loop itself.