### PR TITLE
Vim keybindings

### DIFF
--- a/desktop/sources/index.html
+++ b/desktop/sources/index.html
@@ -65,7 +65,7 @@
       terminal.controller.addSpacer('default', 'View', 'commander')
       terminal.controller.add("default","View","Toggle Commander",() => { terminal.commander.start() },"CmdOrCtrl+K")
       terminal.controller.add("default","View","Run Commander",() => { terminal.commander.run() },"Enter")
-      terminal.controller.add("default","View","Toggle Vim Mode",() => { terminal.commander.toggleVimMode(1) })
+      terminal.controller.add("default","View","Toggle Vim Mode",() => { terminal.commander.toggleVimMode() })
       terminal.controller.addSpacer('default', 'View', 'sizes')
       terminal.controller.add("default","View","Incr. Col",() => { terminal.modGrid(1,0) },"]")
       terminal.controller.add("default","View","Decr. Col",() => { terminal.modGrid(-1,0) },"[")

--- a/desktop/sources/index.html
+++ b/desktop/sources/index.html
@@ -65,6 +65,7 @@
       terminal.controller.addSpacer('default', 'View', 'commander')
       terminal.controller.add("default","View","Toggle Commander",() => { terminal.commander.start() },"CmdOrCtrl+K")
       terminal.controller.add("default","View","Run Commander",() => { terminal.commander.run() },"Enter")
+      terminal.controller.add("default","View","Toggle Vim Mode",() => { terminal.commander.toggleVimMode(1) })
       terminal.controller.addSpacer('default', 'View', 'sizes')
       terminal.controller.add("default","View","Incr. Col",() => { terminal.modGrid(1,0) },"]")
       terminal.controller.add("default","View","Decr. Col",() => { terminal.modGrid(-1,0) },"[")

--- a/desktop/sources/scripts/commander.js
+++ b/desktop/sources/scripts/commander.js
@@ -130,7 +130,11 @@ export default function Commander (terminal) {
   this.toggleVimMode = function (val) {
     this.vimMode = this.vimMode === 0 ? val : 0
     localStorage.setItem(this.vimMode)
-    if (this.vimMode === 0) { this.setEditorMode('insert') }
+    if (this.vimMode === 0) {
+      this.setEditorMode('insert')
+    } else {
+      this.setEditorMode('command')
+    }
   }
 
   this.setEditorMode = function (mode) {

--- a/desktop/sources/scripts/commander.js
+++ b/desktop/sources/scripts/commander.js
@@ -129,7 +129,7 @@ export default function Commander (terminal) {
 
   this.toggleVimMode = function (val) {
     this.vimMode = this.vimMode === 0 ? val : 0
-    localStorage.setItem(this.vimMode)
+    localStorage.setItem('vimMode', this.vimMode)
     if (this.vimMode === 0) {
       this.setEditorMode('insert')
     } else {

--- a/desktop/sources/scripts/commander.js
+++ b/desktop/sources/scripts/commander.js
@@ -188,7 +188,6 @@ export default function Commander (terminal) {
 
     if (event.key === '~') {
       const c = terminal.cursor.read()
-      let out = c;
       if (!/^[a-zA-Z]$/.test(c)) {
         return;
       }
@@ -199,6 +198,15 @@ export default function Commander (terminal) {
       }
       return
     }
+
+    if (modifierOn && event.key === '[') { terminal.toggleGuide(false); terminal.commander.stop(); terminal.clear(); terminal.isPaused = false; terminal.cursor.reset(); return }
+    if (event.key === 'Escape') { terminal.toggleGuide(false); terminal.commander.stop(); terminal.clear(); terminal.isPaused = false; terminal.cursor.reset(); return }
+    if (event.key === 'Backspace') { terminal[this.isActive === true ? 'commander' : 'cursor'].erase(); event.preventDefault(); return }
+
+    // Undo/Redo
+    // key: z
+    if (event.keyCode === 90 && modifierOn && shiftOn) { terminal.history.redo(); event.preventDefault(); return }
+    if (event.keyCode === 90 && modifierOn) { terminal.history.undo(); event.preventDefault(); return }
   }
 
   this.insertModeKeyMapping = function (event) {

--- a/desktop/sources/scripts/commander.js
+++ b/desktop/sources/scripts/commander.js
@@ -6,7 +6,7 @@ export default function Commander (terminal) {
   this.history = []
   this.historyIndex = 0
   this.editorMode = 'insert'
-  this.vimMode = 0
+  this.vimMode = localStorage.getItem('vimMode') || 0;
 
   // Library
 
@@ -129,6 +129,7 @@ export default function Commander (terminal) {
 
   this.toggleVimMode = function (val) {
     this.vimMode = this.vimMode === 0 ? val : 0
+    localStorage.setItem(this.vimMode)
     if (this.vimMode === 0) { this.setEditorMode('insert') }
   }
 

--- a/desktop/sources/scripts/commander.js
+++ b/desktop/sources/scripts/commander.js
@@ -257,11 +257,17 @@ export default function Commander (terminal) {
     }
 
     // Enter command mode if vim mode enabled
-    if (modifierOn && event.key === '[') {
-      if (!this.vimMode) { return }
+    if ((modifierOn && event.key === '[') || event.key === 'Escape') {
       terminal.cursor.reset()
-      this.setEditorMode('command')
+      terminal.toggleGuide(false)
+      terminal.commander.stop()
+      terminal.isPaused = false
       event.preventDefault()
+
+      // This causes a flicker so problematic to do every time escape
+      // is pressed if using vim mode. Possibly need another key to clear
+      if (!this.vimMode) { terminal.clear(); return }
+      this.setEditorMode('command')
       return
     }
 
@@ -301,7 +307,6 @@ export default function Commander (terminal) {
     if (event.key === ' ' && terminal.cursor.mode === 0) { terminal.clock.togglePlay(); event.preventDefault(); return }
     if (event.key === ' ' && terminal.cursor.mode === 1) { terminal.cursor.move(1, 0); event.preventDefault(); return }
 
-    if (event.key === 'Escape') { terminal.toggleGuide(false); terminal.commander.stop(); terminal.clear(); terminal.isPaused = false; terminal.cursor.reset(); return }
     if (event.key === 'Backspace') { terminal[this.isActive === true ? 'commander' : 'cursor'].erase(); event.preventDefault(); return }
 
     if (event.key === ']') { terminal.modGrid(1, 0); event.preventDefault(); return }

--- a/desktop/sources/scripts/commander.js
+++ b/desktop/sources/scripts/commander.js
@@ -165,8 +165,17 @@ export default function Commander (terminal) {
     if (this.editorMode === 'visual') { this.visualModeKeyMapping(event); return }
 
     if (this.editorMode === 'replace') {
+      console.log(event.keyCode, event.key);
       this.insertModeKeyMapping(event)
-      if (event.keyCode >= 48 && event.keyCode <= 90) {
+      if (
+        (event.keyCode >= 48 && event.keyCode <= 90) ||
+        event.key === '=' ||
+        event.key === ';' ||
+        event.key === '*' ||
+        event.key === '%' ||
+        event.key === '!' ||
+        event.key === '#'
+      ) {
         this.setEditorMode('command')
       }
       return

--- a/desktop/sources/scripts/commander.js
+++ b/desktop/sources/scripts/commander.js
@@ -6,7 +6,9 @@ export default function Commander (terminal) {
   this.history = []
   this.historyIndex = 0
   this.editorMode = 'insert'
-  this.vimMode = localStorage.getItem('vimMode') || 0;
+  this.vimMode = false
+
+  if (localStorage.getItem('vimMode') === 'enabled') { this.vimMode = true }
 
   if (this.vimMode) { this.editorMode = 'command' }
 
@@ -129,14 +131,10 @@ export default function Commander (terminal) {
 
   // Events
 
-  this.toggleVimMode = function (val) {
-    this.vimMode = this.vimMode === 0 ? val : 0
-    localStorage.setItem('vimMode', this.vimMode)
-    if (this.vimMode === 0) {
-      this.setEditorMode('insert')
-    } else {
-      this.setEditorMode('command')
-    }
+  this.toggleVimMode = function () {
+    this.vimMode = !this.vimMode
+    localStorage.setItem('vimMode', this.vimMode ? 'enabled' : 'disabled')
+    this.setEditorMode(this.vimMode ? 'command' : 'insert')
   }
 
   this.setEditorMode = function (mode) {

--- a/desktop/sources/scripts/commander.js
+++ b/desktop/sources/scripts/commander.js
@@ -8,6 +8,8 @@ export default function Commander (terminal) {
   this.editorMode = 'insert'
   this.vimMode = localStorage.getItem('vimMode') || 0;
 
+  if (this.vimMode) { this.editorMode = 'command' }
+
   // Library
 
   this.passives = {

--- a/desktop/sources/scripts/commander.js
+++ b/desktop/sources/scripts/commander.js
@@ -145,10 +145,10 @@ export default function Commander (terminal) {
     if (event.keyCode === 90 && (event.metaKey || event.ctrlKey) && event.shiftKey) { terminal.history.redo(); event.preventDefault(); return }
     if (event.keyCode === 90 && (event.metaKey || event.ctrlKey)) { terminal.history.undo(); event.preventDefault(); return }
 
-    if (event.keyCode === 38) { this.onArrowUp(event.shiftKey, (event.metaKey || event.ctrlKey), event.altKey); return }
-    if (event.keyCode === 40) { this.onArrowDown(event.shiftKey, (event.metaKey || event.ctrlKey), event.altKey); return }
-    if (event.keyCode === 37) { this.onArrowLeft(event.shiftKey, (event.metaKey || event.ctrlKey), event.altKey); return }
-    if (event.keyCode === 39) { this.onArrowRight(event.shiftKey, (event.metaKey || event.ctrlKey), event.altKey); return }
+    if (event.keyCode === 38) { this.onCursorUp(event.shiftKey, (event.metaKey || event.ctrlKey), event.altKey); return }
+    if (event.keyCode === 40) { this.onCursorDown(event.shiftKey, (event.metaKey || event.ctrlKey), event.altKey); return }
+    if (event.keyCode === 37) { this.onCursorLeft(event.shiftKey, (event.metaKey || event.ctrlKey), event.altKey); return }
+    if (event.keyCode === 39) { this.onCursorRight(event.shiftKey, (event.metaKey || event.ctrlKey), event.altKey); return }
 
     if (event.keyCode === 9) { terminal.toggleHardmode(); event.preventDefault(); return }
 
@@ -194,7 +194,7 @@ export default function Commander (terminal) {
     }
   }
 
-  this.onArrowDown = function (mod = false, skip = false, drag = false) {
+  this.onCursorDown = function (mod = false, skip = false, drag = false) {
     // Navigate History
     if (this.isActive === true) {
       this.historyIndex += this.historyIndex < this.history.length ? 1 : 0
@@ -212,7 +212,7 @@ export default function Commander (terminal) {
     }
   }
 
-  this.onArrowLeft = function (mod = false, skip = false, drag = false) {
+  this.onCursorLeft = function (mod = false, skip = false, drag = false) {
     const leap = skip ? terminal.grid.w : 1
     terminal.toggleGuide(false)
     if (drag) {
@@ -224,7 +224,7 @@ export default function Commander (terminal) {
     }
   }
 
-  this.onArrowRight = function (mod = false, skip = false, drag = false) {
+  this.onCursorRight = function (mod = false, skip = false, drag = false) {
     const leap = skip ? terminal.grid.w : 1
     terminal.toggleGuide(false)
     if (drag) {


### PR DESCRIPTION
Likely needs a bit of polish but should be enough for people to play with and decide if they like it at this point. Doesn't affect the normal operation of Orca and has to be explicitly enabled from the app menu.

To enable Vim Mode, toggle it from the `View` drop down on the app menu. Once enabled it will automatically start in command mode. There's currently no indicator as to what mode you're in, but I'll add that if people feel this work is useful. The vim mode setting is saved in local storage, so should persist between runs as well.

## Keybindings
`h`, `j`, `k`, `l` as left, down, up, right movement keys respectively
`Escape` or `Ctrl/Meta-[` to enter command mode
`Backspace` or `x` as deletion
`u` as undo
`Ctrl/Meta-r` as redo
`y` as copy
`d` as cut
`p` as paste
`P` as paste with overlap
`a` as select all
`Tab` to toggle hardmode
`:` to enter commands - same as Toggling commander from the `View` drop down
`i` to enter normal Orca control mode
`I` to enter normal Orca control mode but with the cursor in insert mode
`r` to allow replacing of a single character
`~` to switch the case of a letter

Standard movements/selection stuff seems to be working fine, but there may be issues using `Meta` with the movement keys (`Meta-h` automatically hides the active app on OSX for example)

There's certainly more stuff that could/should be added. Mode indicators are the most obvious thing missing. I'm also a very new Orca user, so there may be unforseen issues as well.
Please let me know if you have feedback/issues