### PR TITLE
focus the browser window contents after a menu item is selected

### DIFF
--- a/desktop/sources/scripts/lib/controller.js
+++ b/desktop/sources/scripts/lib/controller.js
@@ -15,7 +15,10 @@ export default function Controller () {
   this.add = function (mode, cat, label, fn, accelerator) {
     if (!this.menu[mode]) { this.menu[mode] = {} }
     if (!this.menu[mode][cat]) { this.menu[mode][cat] = {} }
-    this.menu[mode][cat][label] = { fn: fn, accelerator: accelerator }
+    this.menu[mode][cat][label] = { fn: function(_menuItem, browserWindow) {
+      browserWindow.webContents.focus();
+      fn.apply(this, arguments);
+    }, accelerator: accelerator }
   }
 
   this.addRole = function (mode, cat, label) {


### PR DESCRIPTION
for issue #123 

when a menu item is selected, on some platforms, focus stays on the
menu. This focuses the content after any menu item selection.