### PR TITLE
prevent output port from affecting case

### DIFF
--- a/desktop/core/operator.js
+++ b/desktop/core/operator.js
@@ -120,6 +120,7 @@ export default function Operator (orca, x, y, glyph = '.', passive = false) {
     if (this.ports.output.sensitive !== true) { return false }
     for (const id in ports) {
       const value = this.listen(ports[id])
+      if (ports[id] === this.ports.output) { continue }
       if (value.length !== 1) { continue }
       if (value.toLowerCase() === value.toUpperCase()) { continue }
       if (`${value}`.toUpperCase() === `${value}`) { return true }


### PR DESCRIPTION
- bug (or, let's call it a counter-intuitive oddity): the case of an output in a port marked 'sensitive' would be influenced by what was previously in that port
- with this fix, the output port's content no longer factors into the decision whether the new output should be uppercase or not