### PR TITLE
re-arranged new-cc parameters

### DIFF
--- a/desktop/core/library/_cc.js
+++ b/desktop/core/library/_cc.js
@@ -7,18 +7,18 @@ export default function OperatorCC (orca, x, y) {
 
   this.name = 'cc'
   this.info = 'Sends MIDI cc/program change/pitchbend'
-  this.ports.message = { x: 1, y: 0, clamp: { min: 0, max: 15 } }
-  this.ports.channel = { x: 2, y: 0, clamp: { min: 0, max: 15 } }
-  this.ports.data1 = { x: 3, y: 0, clamp: { min: 0 } }
-  this.ports.data2 = { x: 4, y: 0, clamp: { min: 0 } }
+  this.ports.channel = { x: 1, y: 0, clamp: { min: 0, max: 15 } }
+  this.ports.data1 = { x: 2, y: 0, clamp: { min: 0 } }
+  this.ports.data2 = { x: 3, y: 0, clamp: { min: 0 } }
+  this.ports.message = { x: 4, y: 0, clamp: { min: 0, max: 15 } }
 
   this.operation = function (force = false) {
     if (!this.hasNeighbor('*') && force === false) { return }
-    if (this.listen(this.ports.message) === '.') { return }
     if (this.listen(this.ports.channel) === '.') { return }
     if (this.listen(this.ports.data1) === '.') { return }
+    if (this.listen(this.ports.message) === '.') { return }
 
-    const message = this.listen(this.ports.message, true)
+	const message = this.listen(this.ports.message, true)
     const channel = this.listen(this.ports.channel, true)
 	const data1 = this.listen(this.ports.data1, true)
 	


### PR DESCRIPTION
moved message type parameter to the end 

now it's:
```
1st: channel
2nd: CC number, program #, or pitchbend LSB
3rd: CC value or pitchbend MSB
4th: type 0=cc  1=program change  2=pitchbend
```
