### PR TITLE
add send bank select/pgm change

### DIFF
--- a/desktop/core/io/cc.js
+++ b/desktop/core/io/cc.js
@@ -45,8 +45,12 @@ export default function MidiCC (terminal) {
   }
 
   this.sendPG = function (device, msg) {
-    device.send([0xb0 + msg.channel, 0, msg.bank])
-    device.send([0xb0 + msg.channel, 32, msg.sub])
+  	if (!isNaN(msg.bank)) {
+  		device.send([0xb0 + msg.channel, 0, msg.bank])
+  	}
+    if (!isNaN(msg.sub)) {
+    	device.send([0xb0 + msg.channel, 32, msg.sub])
+    }
     device.send([0xc0 + msg.channel, msg.pgm ])
   }
 }

--- a/desktop/core/io/cc.js
+++ b/desktop/core/io/cc.js
@@ -45,7 +45,8 @@ export default function MidiCC (terminal) {
   }
 
   this.sendPG = function (device, msg) {
-    console.warn('TODO', msg)
-    // device.send([0xb0 + channel, this.offset + value, data[2]])
+    device.send([0xb0 + msg.channel, 0, msg.bank])
+    device.send([0xb0 + msg.channel, 32, msg.sub])
+    device.send([0xc0 + msg.channel, msg.pgm ])
   }
 }


### PR DESCRIPTION
Added bank select/pgm chnage.

Syntax is `pg:chan;bank;sub;pgrm`. Bank and sub are optional - So... `pg:0;;;1` would only send a program change message.

Note: Program change value is 0-127 but the actual number sent via MIDI is 1-128. 