### PR TITLE
change check for msg.channel

### DIFF
--- a/desktop/core/io/cc.js
+++ b/desktop/core/io/cc.js
@@ -57,6 +57,8 @@ export default function MidiCC (terminal) {
     if (!isNaN(msg.sub)) {
     	device.send([0xb0 + msg.channel, 32, msg.sub])
     }
-    device.send([0xc0 + msg.channel, msg.pgm ])
+    if (!isNaN(msg.pgm)) {
+    	device.send([0xc0 + msg.channel, msg.pgm ])
+    }
   }
 }

--- a/desktop/core/io/cc.js
+++ b/desktop/core/io/cc.js
@@ -57,6 +57,8 @@ export default function MidiCC (terminal) {
     if (!isNaN(msg.sub)) {
     	device.send([0xb0 + msg.channel, 32, msg.sub])
     }
-    device.send([0xc0 + msg.channel, msg.pgm ])
+    if (!isNaN(msg.pgm)) {
+	    device.send([0xc0 + msg.channel, msg.pgm ])
+	}
   }
 }

--- a/desktop/core/io/cc.js
+++ b/desktop/core/io/cc.js
@@ -57,8 +57,6 @@ export default function MidiCC (terminal) {
     if (!isNaN(msg.sub)) {
     	device.send([0xb0 + msg.channel, 32, msg.sub])
     }
-    if (!isNaN(msg.pgm)) {
-    	device.send([0xc0 + msg.channel, msg.pgm ])
-    }
+    device.send([0xc0 + msg.channel, msg.pgm ])
   }
 }


### PR DESCRIPTION
Changed check for msg.channel to this: `isNaN(msg.channel)`

Added isNaN check for program change message send

device was already being checked in `this.run` so extra device checks seemed unnecessary.(?)