### PR TITLE
Midi clock

### DIFF
--- a/desktop/core/io/midi.js
+++ b/desktop/core/io/midi.js
@@ -13,7 +13,7 @@ export default function Midi (terminal) {
   this.stack = []
 
   this.keys = {}
-
+  
   this.start = function () {
     console.info('Midi Starting..')
     this.setup()
@@ -125,8 +125,10 @@ export default function Midi (terminal) {
 
   // TODO
   this.sendClock = function () {
+  	this.isClock = true
+  	
     if (!this.outputDevice()) { return }
-    if (this.sendClock !== true) { return }
+    if (this.isClock !== true) { return }
 
     const bpm = terminal.clock.speed.value
     const frameTime = (60000 / bpm) / 4
@@ -135,6 +137,8 @@ export default function Midi (terminal) {
     for (let id = 0; id < 6; id++) {
       if (this.ticks[id]) { clearTimeout(this.ticks[id]) }
       this.ticks[id] = setTimeout(() => { this.outputDevice().send([0xF8], 0) }, parseInt(id) * frameFrag)
+      console.log('Midi', 'send ticks:')
+
     }
   }
 
@@ -152,14 +156,19 @@ export default function Midi (terminal) {
     switch (msg.data[0]) {
       // Clock
       case 0xF8:
+      	//console.log('Midi', 'Clock msg.')
         terminal.clock.tap()
         break
       case 0xFA:
-        console.log('Midi', 'Clock start.')
+        console.log('Midi', 'Start msg.')
+        terminal.clock.play()
+        break
+      case 0xFB:
+        console.log('Midi', 'Continue msg.')
         terminal.clock.play()
         break
       case 0xFC:
-        console.log('Midi', 'Clock stop.')
+        console.log('Midi', 'Stop msg.')
         terminal.clock.stop()
         break
     }

--- a/desktop/core/io/midi.js
+++ b/desktop/core/io/midi.js
@@ -122,6 +122,14 @@ export default function Midi (terminal) {
     this.keys[channel] = null
   }
 
+  this.allNotesOff = function () {
+  	if (!this.outputDevice()) { return }
+  	console.log('Midi', 'All Notes Off')
+  	for (let chan = 0; chan < 16; chan++) {
+      this.outputDevice().send([0xB0 + chan, 123, 0])
+    }
+  }
+
   // Clock
 
   this.ticks = []

--- a/desktop/core/io/midi.js
+++ b/desktop/core/io/midi.js
@@ -4,7 +4,8 @@ import transpose from '../transpose.js'
 
 export default function Midi (terminal) {
   this.mode = 0
-
+  this.isClock = true
+  
   this.outputIndex = -1
   this.inputIndex = -1
 
@@ -82,6 +83,8 @@ export default function Midi (terminal) {
 
   this.update = function () {
     terminal.controller.clearCat('default', 'Midi')
+    terminal.controller.add('default', 'Midi', `MIDI Send Clock ${this.isClock === true ? ' — On' : ' — Off'}`, () => { this.toggleClock(); this.update() }, '')
+    
     terminal.controller.add('default', 'Midi', `Refresh Device List`, () => { terminal.io.midi.setup(); terminal.io.midi.update() })
     terminal.controller.addSpacer('default', 'Midi', 'spacer1')
 
@@ -123,9 +126,19 @@ export default function Midi (terminal) {
 
   this.ticks = []
 
+  this.toggleClock = function() {
+	switch (this.isClock) { 
+		case true:
+			this.isClock = false
+			break
+		case false:
+			this.isClock = true
+			break
+	}
+	
+  }
   // TODO
   this.sendClock = function () {
-  	this.isClock = true
   	
     if (!this.outputDevice()) { return }
     if (this.isClock !== true) { return }

--- a/desktop/core/io/midi.js
+++ b/desktop/core/io/midi.js
@@ -4,7 +4,7 @@ import transpose from '../transpose.js'
 
 export default function Midi (terminal) {
   this.mode = 0
-  this.isClock = true
+  this.isClock = false
   
   this.outputIndex = -1
   this.inputIndex = -1
@@ -166,12 +166,15 @@ export default function Midi (terminal) {
       return
     }
 
+	// listen for clock all the time
+	// check for clock in?
+	if (msg.data[0] === 0xF8){terminal.clock.tap()}
+	
     switch (msg.data[0]) {
       // Clock
-      case 0xF8:
-      	//console.log('Midi', 'Clock msg.')
-        terminal.clock.tap()
-        break
+      //case 0xF8:
+      //  terminal.clock.tap()
+      //  break
       case 0xFA:
         console.log('Midi', 'Start msg.')
         terminal.clock.play()

--- a/desktop/sources/scripts/clock.js
+++ b/desktop/sources/scripts/clock.js
@@ -59,8 +59,7 @@ export default function Clock (terminal) {
  	if (!terminal.io.midi.outputDevice()) { console.warn('Midi', 'No midi output!'); return }
 	terminal.io.midi.outputDevice().send([0xFA], 0)
 	console.log('MIDI', 'Clock Start')
-	//terminal.io.midi.sendClock()
-
+	//terminal.io.midi.isClock = true
   }
 
   this.stop = function () {
@@ -68,7 +67,7 @@ export default function Clock (terminal) {
     console.log('Clock', 'Stop')
     terminal.io.midi.silence()
     terminal.io.midi.outputDevice().send([0xFC], 0)
-    terminal.io.midi.isClock = false
+    //terminal.io.midi.isClock = false
     console.log('MIDI', 'Clock Stop')
     this.isPaused = true
     if (this.isPuppet) { return console.warn('External Midi control') }

--- a/desktop/sources/scripts/clock.js
+++ b/desktop/sources/scripts/clock.js
@@ -40,7 +40,7 @@ export default function Clock (terminal) {
   }
 
   // Controls
-
+    
   this.togglePlay = function () {
     if (this.isPaused === true) {
       this.play()
@@ -55,12 +55,21 @@ export default function Clock (terminal) {
     this.isPaused = false
     if (this.isPuppet) { return console.warn('External Midi control') }
     this.set(this.speed.target, this.speed.target, true)
+ 	
+ 	if (!terminal.io.midi.outputDevice()) { console.warn('Midi', 'No midi output!'); return }
+	terminal.io.midi.outputDevice().send([0xFA], 0)
+	console.log('MIDI', 'Clock Start')
+	//terminal.io.midi.sendClock()
+
   }
 
   this.stop = function () {
     if (this.isPaused) { console.warn('Already stopped'); return }
     console.log('Clock', 'Stop')
     terminal.io.midi.silence()
+    terminal.io.midi.outputDevice().send([0xFC], 0)
+    terminal.io.midi.isClock = false
+    console.log('MIDI', 'Clock Stop')
     this.isPaused = true
     if (this.isPuppet) { return console.warn('External Midi control') }
     this.clearTimer()
@@ -105,7 +114,7 @@ export default function Clock (terminal) {
     this.clearTimer()
     this.timer = new Worker(`${__dirname}/scripts/timer.js`)
     this.timer.postMessage((60000 / bpm) / 4)
-    this.timer.onmessage = (event) => { terminal.run() }
+    this.timer.onmessage = (event) => { terminal.io.midi.sendClock(); terminal.run() }
   }
 
   this.clearTimer = function () {

--- a/desktop/sources/scripts/clock.js
+++ b/desktop/sources/scripts/clock.js
@@ -69,9 +69,11 @@ export default function Clock (terminal) {
     terminal.io.midi.outputDevice().send([0xFC], 0)
     //terminal.io.midi.isClock = false
     console.log('MIDI', 'Clock Stop')
+    terminal.io.midi.allNotesOff()
     this.isPaused = true
     if (this.isPuppet) { return console.warn('External Midi control') }
     this.clearTimer()
+    // needs an all notes off?
   }
 
   // External Clock

--- a/desktop/sources/scripts/source.js
+++ b/desktop/sources/scripts/source.js
@@ -21,7 +21,7 @@ export default function Source (terminal) {
     terminal.resize()
     terminal.history.reset()
     terminal.cursor.reset()
-    terminal.clock.play()
+//    terminal.clock.play()
   }
 
   this.open = function () {


### PR DESCRIPTION
implemented midi clock. Tested with outboard gear and Ableton Live. 

Ableton needs to be set to EXT to receive clock and SYNC/REMOTE should be enabled for the MIDI input device. SYNC/REMOTE should be disabled for **output** if using the same MIDI device.

MIDI Clock is toggled on/off from the MIDI menu.

Spacebar sends MIDI start and stop messages. Stop also sends a MIDI All Notes Off message to avoid hung notes.