### PR TITLE
add themeable transparency

### DIFF
--- a/desktop/main.js
+++ b/desktop/main.js
@@ -20,6 +20,10 @@ let isShown = true
 app.win = null
 
 app.on('ready', () => {
+    setTimeout(app.onReady, 500)
+})
+
+app.onReady = function () {
   require('electron').protocol.registerBufferProtocol('js', protocolHandler)
 
   app.win = new BrowserWindow({
@@ -27,7 +31,7 @@ app.on('ready', () => {
     height: 470,
     minWidth: 310,
     minHeight: 350,
-    backgroundColor: '#000',
+    transparent: true,
     icon: path.join(__dirname, { darwin: 'icon.icns', linux: 'icon.png', win32: 'icon.ico' }[process.platform] || 'icon.ico'),
     resizable: true,
     frame: process.platform !== 'darwin',
@@ -63,7 +67,7 @@ app.on('ready', () => {
       app.win.show()
     }
   })
-})
+}
 
 app.inspect = function () {
   app.win.toggleDevTools()

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "main": "main.js",
   "scripts": {
-    "start": "electron .",
+    "start": "electron --enable-transparent-visuals .",
     "time": "node time.js",
     "docs": "node ../docs.js",
     "fix": "standard --fix",

--- a/desktop/sources/scripts/terminal.js
+++ b/desktop/sources/scripts/terminal.js
@@ -25,7 +25,7 @@ export default function Terminal () {
   this.controller = new Controller()
 
   // Themes
-  this.theme = new Theme({ background: '#000000', f_high: '#ffffff', f_med: '#777777', f_low: '#444444', f_inv: '#000000', b_high: '#eeeeee', b_med: '#72dec2', b_low: '#444444', b_inv: '#ffb545' })
+  this.theme = new Theme({ background: '#000000aa', f_high: '#ffffff', f_med: '#777777', f_low: '#444444', f_inv: '#000000', b_high: '#eeeeee', b_med: '#72dec2', b_low: '#444444', b_inv: '#ffb545' })
 
   this.el = document.createElement('canvas')
   this.context = this.el.getContext('2d')


### PR DESCRIPTION
- enable alpha transparency for electron window
- make the default theme's background slightly transparent (you might need to `Reset Theme` for this to show)
- alpha values can be specified in custom svg themes (i.e. `#0000` for full transparency)
- might not work on some linux nvidia drivers without adding `--disable-gpu` argument
- only tested on linux intel driver, sorry