### PR TITLE
Trigger noteon for zero-length MIDI notes

### DIFF
--- a/desktop/sources/scripts/core/io/midi.js
+++ b/desktop/sources/scripts/core/io/midi.js
@@ -25,14 +25,14 @@ function Midi (client) {
   this.run = function () {
     for (const id in this.stack) {
       const item = this.stack[id]
+      if (item.isPlayed === false) {
+        this.press(item)
+      }
       if (item.length < 1) {
         this.release(item, id)
+      } else {
+        item.length--
       }
-      if (!this.stack[id]) { continue }
-      if (this.stack[id].isPlayed === false) {
-        this.press(this.stack[id])
-      }
-      this.stack[id].length--
     }
   }
 


### PR DESCRIPTION
Currently, MIDI notes with zero length (for example: `:03A.0`) send a noteoff message without a corresponding noteon first, which is kinda weird.

This change makes such a note send a noteon immediately followed by a noteoff.