### PR TITLE
Enable multiple midi device output via channel expansion

### DIFF
--- a/desktop/sources/scripts/core/io/midi.js
+++ b/desktop/sources/scripts/core/io/midi.js
@@ -40,7 +40,9 @@ function Midi (client) {
     if (!this.outputDevice()) { console.warn('MIDI', 'No midi output!'); return }
 
     const transposed = this.transpose(item.note, item.octave)
-    const channel = !isNaN(item.channel) ? parseInt(item.channel) : client.orca.valueOf(item.channel)
+    const rawChannel = !isNaN(item.channel) ? parseInt(item.channel) : client.orca.valueOf(item.channel)
+    const deviceOffset = Math.floor(rawChannel / 16)
+    const channel = rawChannel % 16
 
     if (!transposed) { return }
 
@@ -50,7 +52,9 @@ function Midi (client) {
 
     if (!n || c === 127) { return }
 
-    this.outputDevice().send([c, n, v])
+    if (this.outputIndex + deviceOffset < this.outputs.length) {
+      this.outputs[this.outputIndex + deviceOffset].send([c, n, v])
+    }
   }
 
   this.press = function (item) {

--- a/desktop/sources/scripts/core/library.js
+++ b/desktop/sources/scripts/core/library.js
@@ -545,7 +545,6 @@ library[':'] = function OperatorMidi (orca, x, y, passive) {
     if (!isNaN(this.listen(this.ports.note))) { return }
 
     const channel = this.listen(this.ports.channel, true)
-    if (channel > 15) { return }
     const octave = this.listen(this.ports.octave, true)
     const note = this.listen(this.ports.note)
     const velocity = this.listen(this.ports.velocity, true)
@@ -576,7 +575,6 @@ library['!'] = function OperatorCC (orca, x, y) {
     if (this.listen(this.ports.knob) === '.') { return }
 
     const channel = this.listen(this.ports.channel, true)
-    if (channel > 15) { return }
     const knob = this.listen(this.ports.knob, true)
     const rawValue = this.listen(this.ports.value, true)
     const value = Math.ceil((127 * rawValue) / 35)
@@ -640,7 +638,6 @@ library['%'] = function OperatorMono (orca, x, y, passive) {
     if (!isNaN(this.listen(this.ports.note))) { return }
 
     const channel = this.listen(this.ports.channel, true)
-    if (channel > 15) { return }
     const octave = this.listen(this.ports.octave, true)
     const note = this.listen(this.ports.note)
     const velocity = this.listen(this.ports.velocity, true)


### PR DESCRIPTION
Channel numbers above 15 go to the next device on the list. This enables a total of 36 channels across 3 consecutive devices.

A little crude (cannot control device ordering in Orca, must depend on how the system reports them) but effective. 

Example setup on OSX with Bitwig:

![image](https://user-images.githubusercontent.com/925755/94365161-e62e7780-00ce-11eb-87ab-28a3d91db864.png)

![image](https://user-images.githubusercontent.com/925755/94365181-08c09080-00cf-11eb-8995-1dafeb03bd1a.png)

![image](https://user-images.githubusercontent.com/925755/94365211-3a395c00-00cf-11eb-9447-eb0291962686.png)

![image](https://user-images.githubusercontent.com/925755/94365226-5a691b00-00cf-11eb-9830-be3d0db8a669.png)
