### PR TITLE
Dynamically loadable language libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,13 +70,13 @@ To display the list of operators inside of Orca, use `CmdOrCtrl+G`.
 
 ## MIDI
 
-The [MIDI](https://en.wikipedia.org/wiki/MIDI) operator `:` takes up to 5 inputs('channel, 'octave, 'note, velocity, length). 
+The [MIDI](https://en.wikipedia.org/wiki/MIDI) operator `:` takes up to 5 inputs('channel, 'octave, 'note, velocity, length).
 
 For example, `:25C`, is a **C note, on the 5th octave, through the 3rd MIDI channel**, `:04c`, is a **C# note, on the 4th octave, through the 1st MIDI channel**. Velocity is an optional value from `0`(0/127) to `g`(127/127). Note length is the number of frames during which a note remains active. See it in action with [midi.orca](https://git.sr.ht/~rabbits/orca-examples/tree/master/basics/_midi.orca).
 
 ## MIDI MONO
 
-The [MONO](https://en.wikipedia.org/wiki/Monophony) operator `%` takes up to 5 inputs('channel, 'octave, 'note, velocity, length). 
+The [MONO](https://en.wikipedia.org/wiki/Monophony) operator `%` takes up to 5 inputs('channel, 'octave, 'note, velocity, length).
 
 This operator is very similar to the default Midi operator, but **each new note will stop the previously playing note**, would its length overlap with the new one. Making certain that only a single note is ever played at once, this is ideal for monophonic analog synthetisers that might struggle to dealing with chords and note overlaps.
 
@@ -94,9 +94,9 @@ It sends two different values **between 0-127**, where the value is calculated a
 
 ## MIDI BANK SELECT / PROGRAM CHANGE
 
-This is a command (see below) rather than an operator and it combines the [MIDI program change and bank select functions](https://www.sweetwater.com/sweetcare/articles/6-what-msb-lsb-refer-for-changing-banks-andprograms/). 
+This is a command (see below) rather than an operator and it combines the [MIDI program change and bank select functions](https://www.sweetwater.com/sweetcare/articles/6-what-msb-lsb-refer-for-changing-banks-andprograms/).
 
-The syntax is `pg:channel;msb;lsb;program`. Channel is 0-15, msb/lsb/program are 0-127, but program will automatically be translated to 1-128 by the MIDI driver. `program` typically correspondes to a "patch" selection on a synth. Note that `msb` may also be identified as "bank" and `lsb` as "sub" in some applications (like Ableton Live). 
+The syntax is `pg:channel;msb;lsb;program`. Channel is 0-15, msb/lsb/program are 0-127, but program will automatically be translated to 1-128 by the MIDI driver. `program` typically correspondes to a "patch" selection on a synth. Note that `msb` may also be identified as "bank" and `lsb` as "sub" in some applications (like Ableton Live).
 
 `msb` and `lsb` can be left blank if you only want to send a simple program change. For example, `pg:0;;;63` will set the synth to patch number 64 (without changing the bank)
 
@@ -149,30 +149,31 @@ All commands have a shorthand equivalent to their first two characters, for exam
 - `midi:1;2` Set Midi output device to `#1`, and input device to `#2`.
 - `udp:1234;5678` Set UDP output port to `1234`, and input port to `5678`.
 - `osc:1234` Set OSC output port to `1234`.
+- `lang:clr;default` Incrementally load language interpreters (`clr` clears the language library entirely). Multiple languages can be combined.
 
 ## Base36 Table
 
-Orca operates on a base of **36 increments**. Operators using numeric values will typically also operate on letters and convert them into values as per the following table. For instance `Do` will bang every *24th frame*. 
+Orca operates on a base of **36 increments**. Operators using numeric values will typically also operate on letters and convert them into values as per the following table. For instance `Do` will bang every *24th frame*.
 
-| **0** | **1** | **2** | **3** | **4** | **5** | **6** | **7** | **8** | **9** | **A** | **B**  | 
-| :-:   | :-:   | :-:   | :-:   | :-:   | :-:   | :-:   | :-:   | :-:   | :-:   | :-:   | :-:    | 
+| **0** | **1** | **2** | **3** | **4** | **5** | **6** | **7** | **8** | **9** | **A** | **B**  |
+| :-:   | :-:   | :-:   | :-:   | :-:   | :-:   | :-:   | :-:   | :-:   | :-:   | :-:   | :-:    |
 | 0     | 1     | 2     | 3     | 4     | 5     | 6     | 7     | 8     | 9     | 10    | 11     |
 | **C** | **D** | **E** | **F** | **G** | **H** | **I** | **J** | **K** | **L** | **M** | **N**  |
 | 12    | 13    | 14    | 15    | 16    | 17    | 18    | 19    | 20    | 21    | 22    | 23     |
-| **O** | **P** | **Q** | **R** | **S** | **T** | **U** | **V** | **W** | **X** | **Y** | **Z**  | 
+| **O** | **P** | **Q** | **R** | **S** | **T** | **U** | **V** | **W** | **X** | **Y** | **Z**  |
 | 24    | 25    | 26    | 27    | 28    | 29    | 30    | 31    | 32    | 33    | 34    | 35     |
 
 ## Transpose Table
 
 The midi operator interprets any letter above the chromatic scale as a transpose value, for instance `3H`, is equivalent to `4A`.
 
-| **0** | **1** | **2** | **3** | **4** | **5** | **6** | **7** | **8** | **9** | **A** | **B**  | 
-| :-:   | :-:   | :-:   | :-:   | :-:   | :-:   | :-:   | :-:   | :-:   | :-:   | :-:   | :-:    | 
+| **0** | **1** | **2** | **3** | **4** | **5** | **6** | **7** | **8** | **9** | **A** | **B**  |
+| :-:   | :-:   | :-:   | :-:   | :-:   | :-:   | :-:   | :-:   | :-:   | :-:   | :-:   | :-:    |
 | _     | _     | _     | _     | _     | _     | _     | _     | _     | _     | A0    | B0     |
 | **C** | **D** | **E** | **F** | **G** | **H** | **I** | **J** | **K** | **L** | **M** | **N**  |
-| C0    | D0    | E0    | F0    | G0    | A0    | B0    | C1    | D1    | E1    | F1    | G1     | 
-| **O** | **P** | **Q** | **R** | **S** | **T** | **U** | **V** | **W** | **X** | **Y** | **Z**  | 
-| A1    | B1    | C2    | D2    | E2    | F2    | G2    | A2    | B2    | C3    | D3    | E3     | 
+| C0    | D0    | E0    | F0    | G0    | A0    | B0    | C1    | D1    | E1    | F1    | G1     |
+| **O** | **P** | **Q** | **R** | **S** | **T** | **U** | **V** | **W** | **X** | **Y** | **Z**  |
+| A1    | B1    | C2    | D2    | E2    | F2    | G2    | A2    | B2    | C3    | D3    | E3     |
 
 ## Companion Applications
 

--- a/desktop/sources/index.html
+++ b/desktop/sources/index.html
@@ -6,7 +6,9 @@
     <script type="text/javascript" src="scripts/lib/theme.js"></script>
     <script type="text/javascript" src="scripts/lib/history.js"></script>
     <script type="text/javascript" src="scripts/lib/source.js"></script>
-    <script type="text/javascript" src="scripts/core/library.js"></script>
+    <script type="text/javascript" src="scripts/core/library/library.js"></script>
+    <script type="text/javascript" src="scripts/core/library/base.js"></script>
+    <script type="text/javascript" src="scripts/core/library/default.js"></script>
     <script type="text/javascript" src="scripts/core/io.js"></script>
     <script type="text/javascript" src="scripts/core/operator.js"></script>
     <script type="text/javascript" src="scripts/core/orca.js"></script>
@@ -30,7 +32,7 @@
 
       client.install(document.body)
 
-      window.addEventListener('load', () => { 
+      window.addEventListener('load', () => {
         client.start()
         client.acels.inject('Orca')
       })

--- a/desktop/sources/scripts/client.js
+++ b/desktop/sources/scripts/client.js
@@ -12,8 +12,9 @@
 /* global Theme */
 
 function Client () {
-  this.version = 176
-  this.library = library
+  this.version = 177
+  this.libraryName = 'default'
+  this.library = library[this.libraryName]
 
   this.theme = new Theme(this)
   this.acels = new Acels(this)
@@ -331,7 +332,13 @@ function Client () {
     } else {
       this.write(this.orca.f < 25 ? `ver${this.version}` : `${Object.keys(this.source.cache).length} mods`, this.grid.w * 0, this.orca.h + 1, this.grid.w)
       this.write(`${this.orca.w}x${this.orca.h}`, this.grid.w * 1, this.orca.h + 1, this.grid.w)
-      this.write(`${this.grid.w}/${this.grid.h}${this.tile.w !== 10 ? ' ' + (this.tile.w / 10).toFixed(1) : ''}`, this.grid.w * 2, this.orca.h + 1, this.grid.w)
+      this.write(
+        this.orca.f < 25
+        ? `${this.libraryName}`
+        : `${this.grid.w}/${this.grid.h}${this.tile.w !== 10 ? ' ' + (this.tile.w / 10).toFixed(1) : ''}`,
+        this.grid.w * 2,
+        this.orca.h + 1,
+        this.grid.w)
       this.write(`${this.clock}`, this.grid.w * 3, this.orca.h + 1, this.grid.w, this.clock.isPuppet ? 3 : this.io.midi.isClock ? 11 : this.clock.isPaused ? 20 : 2)
       this.write(`${display(Object.keys(this.orca.variables).join(''), this.orca.f, this.grid.w - 1)}`, this.grid.w * 4, this.orca.h + 1, this.grid.w - 1)
       this.write(this.orca.f < 250 ? `> ${this.io.midi.toOutputString()}` : '', this.grid.w * 5, this.orca.h + 1, this.grid.w * 4)

--- a/desktop/sources/scripts/commander.js
+++ b/desktop/sources/scripts/commander.js
@@ -1,5 +1,7 @@
 'use strict'
 
+/* global library */
+
 function Commander (client) {
   this.isActive = false
   this.query = ''
@@ -70,7 +72,28 @@ function Commander (client) {
     },
     write: (p) => {
       client.orca.writeBlock(p._x || client.cursor.x, p._y || client.cursor.y, p._str)
-    }
+    },
+    // Language
+    lang: (p) => {
+      p.parts.forEach(l => {
+        if (l === 'clr') {
+          console.log('Clearing lang'),
+          client.library = {}
+          client.libraryName = '---'
+        } else {
+          if (l in library) {
+            console.log(`Incrementally loading lang: ${l}`)
+            client.library = Object.assign({}, client.library, library[l])
+            client.libraryName = l
+          } else {
+            console.error(`Lang ${l} is not defined`)
+            return
+          }
+        }
+        client.orca.library = client.library
+        client.clock.setFrame(0)
+    })
+    },
   }
 
   // Make shorthands

--- a/desktop/sources/scripts/core/library/base.js
+++ b/desktop/sources/scripts/core/library/base.js
@@ -5,6 +5,22 @@
 
 library.base = {}
 
+library.base['#'] = function OperatorComment (orca, x, y, passive) {
+    Operator.call(this, orca, x, y, '#', true)
+
+    this.name = 'comment'
+    this.info = 'Halts line'
+    this.draw = false
+
+    this.operation = function () {
+      for (let x = this.x + 1; x <= orca.w; x++) {
+        orca.lock(x, this.y)
+        if (orca.glyphAt(x, this.y) === this.glyph) { break }
+      }
+      orca.lock(this.x, this.y)
+    }
+}
+
 for (let i = 0; i <= 9; i++) {
     library.base[`${i}`] = function OperatorNull (orca, x, y, passive) {
       Operator.call(this, orca, x, y, '.', false)

--- a/desktop/sources/scripts/core/library/base.js
+++ b/desktop/sources/scripts/core/library/base.js
@@ -1,0 +1,20 @@
+`use strict`
+
+/* global Operator */
+/* global library */
+
+library.base = {}
+
+for (let i = 0; i <= 9; i++) {
+    library.base[`${i}`] = function OperatorNull (orca, x, y, passive) {
+      Operator.call(this, orca, x, y, '.', false)
+
+      this.name = 'null'
+      this.info = 'empty'
+
+      // Overwrite run, to disable draw.
+      this.run = function (force = false) {
+
+      }
+    }
+}

--- a/desktop/sources/scripts/core/library/default.js
+++ b/desktop/sources/scripts/core/library/default.js
@@ -2,10 +2,12 @@
 
 /* global Operator */
 /* global client */
+/* global library */
 
-const library = {}
+library.default = {}
+var defaultLib = library.default
 
-library.a = function OperatorA (orca, x, y, passive) {
+defaultLib.a = function OperatorA (orca, x, y, passive) {
   Operator.call(this, orca, x, y, 'a', passive)
 
   this.name = 'add'
@@ -22,7 +24,7 @@ library.a = function OperatorA (orca, x, y, passive) {
   }
 }
 
-library.b = function OperatorL (orca, x, y, passive) {
+defaultLib.b = function OperatorL (orca, x, y, passive) {
   Operator.call(this, orca, x, y, 'b', passive)
 
   this.name = 'subtract'
@@ -39,7 +41,7 @@ library.b = function OperatorL (orca, x, y, passive) {
   }
 }
 
-library.c = function OperatorC (orca, x, y, passive) {
+defaultLib.c = function OperatorC (orca, x, y, passive) {
   Operator.call(this, orca, x, y, 'c', passive)
 
   this.name = 'clock'
@@ -57,7 +59,7 @@ library.c = function OperatorC (orca, x, y, passive) {
   }
 }
 
-library.d = function OperatorD (orca, x, y, passive) {
+defaultLib.d = function OperatorD (orca, x, y, passive) {
   Operator.call(this, orca, x, y, 'd', passive)
 
   this.name = 'delay'
@@ -75,7 +77,7 @@ library.d = function OperatorD (orca, x, y, passive) {
   }
 }
 
-library.e = function OperatorE (orca, x, y, passive) {
+defaultLib.e = function OperatorE (orca, x, y, passive) {
   Operator.call(this, orca, x, y, 'e', passive)
 
   this.name = 'east'
@@ -88,7 +90,7 @@ library.e = function OperatorE (orca, x, y, passive) {
   }
 }
 
-library.f = function OperatorF (orca, x, y, passive) {
+defaultLib.f = function OperatorF (orca, x, y, passive) {
   Operator.call(this, orca, x, y, 'f', passive)
 
   this.name = 'if'
@@ -105,7 +107,7 @@ library.f = function OperatorF (orca, x, y, passive) {
   }
 }
 
-library.g = function OperatorG (orca, x, y, passive) {
+defaultLib.g = function OperatorG (orca, x, y, passive) {
   Operator.call(this, orca, x, y, 'g', passive)
 
   this.name = 'generator'
@@ -130,7 +132,7 @@ library.g = function OperatorG (orca, x, y, passive) {
   }
 }
 
-library.h = function OperatorH (orca, x, y, passive) {
+defaultLib.h = function OperatorH (orca, x, y, passive) {
   Operator.call(this, orca, x, y, 'h', passive)
 
   this.name = 'halt'
@@ -144,7 +146,7 @@ library.h = function OperatorH (orca, x, y, passive) {
   }
 }
 
-library.i = function OperatorI (orca, x, y, passive) {
+defaultLib.i = function OperatorI (orca, x, y, passive) {
   Operator.call(this, orca, x, y, 'i', passive)
 
   this.name = 'increment'
@@ -162,7 +164,7 @@ library.i = function OperatorI (orca, x, y, passive) {
   }
 }
 
-library.j = function OperatorJ (orca, x, y, passive) {
+defaultLib.j = function OperatorJ (orca, x, y, passive) {
   Operator.call(this, orca, x, y, 'j', passive)
 
   this.name = 'jumper'
@@ -177,7 +179,7 @@ library.j = function OperatorJ (orca, x, y, passive) {
   }
 }
 
-library.k = function OperatorK (orca, x, y, passive) {
+defaultLib.k = function OperatorK (orca, x, y, passive) {
   Operator.call(this, orca, x, y, 'k', passive)
 
   this.name = 'konkat'
@@ -201,7 +203,7 @@ library.k = function OperatorK (orca, x, y, passive) {
   }
 }
 
-library.l = function OperatorL (orca, x, y, passive) {
+defaultLib.l = function OperatorL (orca, x, y, passive) {
   Operator.call(this, orca, x, y, 'l', passive)
 
   this.name = 'lesser'
@@ -218,7 +220,7 @@ library.l = function OperatorL (orca, x, y, passive) {
   }
 }
 
-library.m = function OperatorM (orca, x, y, passive) {
+defaultLib.m = function OperatorM (orca, x, y, passive) {
   Operator.call(this, orca, x, y, 'm', passive)
 
   this.name = 'multiply'
@@ -235,7 +237,7 @@ library.m = function OperatorM (orca, x, y, passive) {
   }
 }
 
-library.n = function OperatorN (orca, x, y, passive) {
+defaultLib.n = function OperatorN (orca, x, y, passive) {
   Operator.call(this, orca, x, y, 'n', passive)
 
   this.name = 'north'
@@ -248,7 +250,7 @@ library.n = function OperatorN (orca, x, y, passive) {
   }
 }
 
-library.o = function OperatorO (orca, x, y, passive) {
+defaultLib.o = function OperatorO (orca, x, y, passive) {
   Operator.call(this, orca, x, y, 'o', passive)
 
   this.name = 'read'
@@ -266,7 +268,7 @@ library.o = function OperatorO (orca, x, y, passive) {
   }
 }
 
-library.p = function OperatorP (orca, x, y, passive) {
+defaultLib.p = function OperatorP (orca, x, y, passive) {
   Operator.call(this, orca, x, y, 'p', passive)
 
   this.name = 'push'
@@ -287,7 +289,7 @@ library.p = function OperatorP (orca, x, y, passive) {
   }
 }
 
-library.q = function OperatorQ (orca, x, y, passive) {
+defaultLib.q = function OperatorQ (orca, x, y, passive) {
   Operator.call(this, orca, x, y, 'q', passive)
 
   this.name = 'query'
@@ -312,7 +314,7 @@ library.q = function OperatorQ (orca, x, y, passive) {
   }
 }
 
-library.r = function OperatorR (orca, x, y, passive) {
+defaultLib.r = function OperatorR (orca, x, y, passive) {
   Operator.call(this, orca, x, y, 'r', passive)
 
   this.name = 'random'
@@ -330,7 +332,7 @@ library.r = function OperatorR (orca, x, y, passive) {
   }
 }
 
-library.s = function OperatorS (orca, x, y, passive) {
+defaultLib.s = function OperatorS (orca, x, y, passive) {
   Operator.call(this, orca, x, y, 's', passive)
 
   this.name = 'south'
@@ -343,7 +345,7 @@ library.s = function OperatorS (orca, x, y, passive) {
   }
 }
 
-library.t = function OperatorT (orca, x, y, passive) {
+defaultLib.t = function OperatorT (orca, x, y, passive) {
   Operator.call(this, orca, x, y, 't', passive)
 
   this.name = 'track'
@@ -364,7 +366,7 @@ library.t = function OperatorT (orca, x, y, passive) {
   }
 }
 
-library.u = function OperatorU (orca, x, y, passive) {
+defaultLib.u = function OperatorU (orca, x, y, passive) {
   Operator.call(this, orca, x, y, 'u', passive)
 
   this.name = 'uclid'
@@ -382,7 +384,7 @@ library.u = function OperatorU (orca, x, y, passive) {
   }
 }
 
-library.v = function OperatorV (orca, x, y, passive) {
+defaultLib.v = function OperatorV (orca, x, y, passive) {
   Operator.call(this, orca, x, y, 'v', passive)
 
   this.name = 'variable'
@@ -405,7 +407,7 @@ library.v = function OperatorV (orca, x, y, passive) {
   }
 }
 
-library.w = function OperatorW (orca, x, y, passive) {
+defaultLib.w = function OperatorW (orca, x, y, passive) {
   Operator.call(this, orca, x, y, 'w', passive)
 
   this.name = 'west'
@@ -418,7 +420,7 @@ library.w = function OperatorW (orca, x, y, passive) {
   }
 }
 
-library.x = function OperatorX (orca, x, y, passive) {
+defaultLib.x = function OperatorX (orca, x, y, passive) {
   Operator.call(this, orca, x, y, 'x', passive)
 
   this.name = 'write'
@@ -436,7 +438,7 @@ library.x = function OperatorX (orca, x, y, passive) {
   }
 }
 
-library.y = function OperatorY (orca, x, y, passive) {
+defaultLib.y = function OperatorY (orca, x, y, passive) {
   Operator.call(this, orca, x, y, 'y', passive)
 
   this.name = 'jymper'
@@ -451,7 +453,7 @@ library.y = function OperatorY (orca, x, y, passive) {
   }
 }
 
-library.z = function OperatorZ (orca, x, y, passive) {
+defaultLib.z = function OperatorZ (orca, x, y, passive) {
   Operator.call(this, orca, x, y, 'z', passive)
 
   this.name = 'lerp'
@@ -472,7 +474,7 @@ library.z = function OperatorZ (orca, x, y, passive) {
 
 // Specials
 
-library['*'] = function OperatorBang (orca, x, y, passive) {
+defaultLib['*'] = function OperatorBang (orca, x, y, passive) {
   Operator.call(this, orca, x, y, '*', true)
 
   this.name = 'bang'
@@ -485,7 +487,7 @@ library['*'] = function OperatorBang (orca, x, y, passive) {
   }
 }
 
-library['#'] = function OperatorComment (orca, x, y, passive) {
+defaultLib['#'] = function OperatorComment (orca, x, y, passive) {
   Operator.call(this, orca, x, y, '#', true)
 
   this.name = 'comment'
@@ -503,7 +505,7 @@ library['#'] = function OperatorComment (orca, x, y, passive) {
 
 // IO
 
-library.$ = function OperatorSelf (orca, x, y, passive) {
+defaultLib.$ = function OperatorSelf (orca, x, y, passive) {
   Operator.call(this, orca, x, y, '*', true)
 
   this.name = 'self'
@@ -526,7 +528,7 @@ library.$ = function OperatorSelf (orca, x, y, passive) {
   }
 }
 
-library[':'] = function OperatorMidi (orca, x, y, passive) {
+defaultLib[':'] = function OperatorMidi (orca, x, y, passive) {
   Operator.call(this, orca, x, y, ':', true)
 
   this.name = 'midi'
@@ -561,7 +563,7 @@ library[':'] = function OperatorMidi (orca, x, y, passive) {
   }
 }
 
-library['!'] = function OperatorCC (orca, x, y) {
+defaultLib['!'] = function OperatorCC (orca, x, y) {
   Operator.call(this, orca, x, y, '!', true)
 
   this.name = 'cc'
@@ -591,7 +593,7 @@ library['!'] = function OperatorCC (orca, x, y) {
   }
 }
 
-library['?'] = function OperatorPB (orca, x, y) {
+defaultLib['?'] = function OperatorPB (orca, x, y) {
   Operator.call(this, orca, x, y, '?', true)
 
   this.name = 'pb'
@@ -621,7 +623,7 @@ library['?'] = function OperatorPB (orca, x, y) {
   }
 }
 
-library['%'] = function OperatorMono (orca, x, y, passive) {
+defaultLib['%'] = function OperatorMono (orca, x, y, passive) {
   Operator.call(this, orca, x, y, '%', true)
 
   this.name = 'mono'
@@ -656,7 +658,7 @@ library['%'] = function OperatorMono (orca, x, y, passive) {
   }
 }
 
-library['='] = function OperatorOsc (orca, x, y, passive) {
+defaultLib['='] = function OperatorOsc (orca, x, y, passive) {
   Operator.call(this, orca, x, y, '=', true)
 
   this.name = 'osc'
@@ -688,7 +690,7 @@ library['='] = function OperatorOsc (orca, x, y, passive) {
   }
 }
 
-library[';'] = function OperatorUdp (orca, x, y, passive) {
+defaultLib[';'] = function OperatorUdp (orca, x, y, passive) {
   Operator.call(this, orca, x, y, ';', true)
 
   this.name = 'udp'
@@ -717,7 +719,7 @@ library[';'] = function OperatorUdp (orca, x, y, passive) {
 // Add numbers
 
 for (let i = 0; i <= 9; i++) {
-  library[`${i}`] = function OperatorNull (orca, x, y, passive) {
+  defaultLib[`${i}`] = function OperatorNull (orca, x, y, passive) {
     Operator.call(this, orca, x, y, '.', false)
 
     this.name = 'null'

--- a/desktop/sources/scripts/core/library/library.js
+++ b/desktop/sources/scripts/core/library/library.js
@@ -1,0 +1,3 @@
+'use strict'
+
+const library = {}

--- a/desktop/sources/scripts/core/orca.js
+++ b/desktop/sources/scripts/core/orca.js
@@ -1,6 +1,7 @@
 'use strict'
 
 function Orca (library) {
+  this.library = library
   this.keys = '0123456789abcdefghijklmnopqrstuvwxyz'.split('')
 
   this.w = 1 // Default Width
@@ -63,7 +64,7 @@ function Orca (library) {
       for (let x = 0; x < this.w; x++) {
         const g = this.glyphAt(x, y)
         if (g === '.' || !this.isAllowed(g)) { continue }
-        a.push(new library[g.toLowerCase()](this, x, y, g === g.toUpperCase()))
+        a.push(new this.library[g.toLowerCase()](this, x, y, g === g.toUpperCase()))
       }
     }
     return a
@@ -146,7 +147,7 @@ function Orca (library) {
   }
 
   this.isAllowed = function (g) {
-    return g === '.' || !!library[`${g}`.toLowerCase()]
+    return g === '.' || !!this.library[`${g}`.toLowerCase()]
   }
 
   this.isSpecial = function (g) {


### PR DESCRIPTION
Adds ability to load alternative languages via `lang` command. ATM this is a PoC, comments and critique welcome and appreciated, especially on ways to better name and organize things, currently they be clunky.

Default behavior of Orca is unchanged. Language implementations can be replaced on the fly with the `lang` command:

* takes a `;`-separated list of names
* languages are loaded incrementally, each can (re)define all operators, or some, or even none at all
* original implementation is called `default`
* `clr` is a special name, removes all operator definitions

Internally, the language is a dict of operator definitions, now there are several, placed in `library` directory where `library.js` originally was. For now, only the original (`default`) and `base` (not useful by itself but added as a basis for new definitions). New language definition `foo` can be added by defining `library.foo`.

Changes:

* Moved `library.js` to `library/default.js`
* `library` changed from an object of operators to object of objects of operators, original `library` became `library.default`
* Added `lang` command
* Added `this.library` attribute to `Orca` class, for dynamic overloading
* Current lang name is displayed for first 25 frames (frame counter resets when changing languages)
* Updated `README.md`