### PR TITLE
Operator V output port aesthetics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 builds/
 .DS_Store
 */.DS_Store
+.vscode/

--- a/desktop/sources/scripts/core/library.js
+++ b/desktop/sources/scripts/core/library.js
@@ -395,7 +395,7 @@ library.v = function OperatorV (orca, x, y, passive) {
     const write = this.listen(this.ports.write)
     const read = this.listen(this.ports.read)
     if (write === '.' && read !== '.') {
-      this.addPort('output', { x: 0, y: 1 })
+      this.addPort('output', { x: 0, y: 1, output: true })
     }
     if (write !== '.') {
       orca.variables[write] = read


### PR DESCRIPTION
This small PR makes sure the output port of operator `V` is visually marked as an output port:

<img width="842" alt="Screenshot 2020-11-09 at 21 38 53" src="https://user-images.githubusercontent.com/3680855/98595640-88e53300-22d6-11eb-9bfc-18607653ab9b.png">

(also sneaked the `.vscode/` directory into `.gitignore` so I won't accidentally check in my debugging configuration 😉)