### PR TITLE
Remove reference to WORKSHOP.md from tutorial

### DIFF
--- a/resources/TUTORIAL.md
+++ b/resources/TUTORIAL.md
@@ -1,6 +1,6 @@
 # Tutorial
 
-If this is your first time trying out **Orca**, watch this [introduction video](https://www.youtube.com/watch?v=RaI_TuISSJE). If you want to learn how to use a handful of basic operators, have a look at the [workshop](WORKSHOP.md). If you're looking for additional examples, visit [this repository](https://git.sr.ht/~rabbits/orca-examples/tree/master/).
+If this is your first time trying out **Orca**, watch this [introduction video](https://www.youtube.com/watch?v=RaI_TuISSJE). If you're looking for additional examples, visit [this repository](https://git.sr.ht/~rabbits/orca-examples/tree/master/).
 
 ## General
 


### PR DESCRIPTION
The workshop was actually deleted in 7e520805a29a8e2421636ab7dfe1384683017d12, so this link doesn't lead anywhere currently.